### PR TITLE
feat: integrate litepaper assets into documentation

### DIFF
--- a/docs/docs/DCT/introduction.md
+++ b/docs/docs/DCT/introduction.md
@@ -5,6 +5,8 @@ title: Decentralized Custody Tokens
 
 # Decentralized Custody Tokens (DCTs)
 
+![Zenrock DCTs](/img/litepaper/zenrock%20DCTs%201.png)
+
 A DCT is any token issued through Zenrock's decentralized custody network. Secured by dMPC and anchored by zrChain, DCTs set a new standard for cross-chain asset custody.
 
 DCTs are more than wrappers. They're a security foundation. DeFi primitives can be built on top: structured products, leveraged vaults, restaking strategies. Developers take creative risks. Users choose their exposure. **The underlying custody stays the same.**

--- a/docs/docs/Hush/introduction.md
+++ b/docs/docs/Hush/introduction.md
@@ -5,6 +5,8 @@ title: Hush Protocol
 
 # Hush Protocol
 
+![Hush Protocol](/img/litepaper/hush%20protocol%20graphic%201.png)
+
 Use Hush: [https://hushprotocol.xyz](https://hushprotocol.xyz)
 
 Security Audit: [Hush Protocol Audit (PDF)](/zenrock-hush-protocol-audit.pdf)
@@ -19,6 +21,8 @@ Hush enables anonymity via a shielded asset pool. Users deposit ("shield") jitoS
 - **Unshield to any address**—with no onchain link to the original deposit
 
 This creates an entirely private economy within the pool. Users can receive funds, send payments, and transact multiple times—all without touching public Solana until they choose to.
+
+![Hush Private Economy Pool](/img/litepaper/hush%20private%20economy%20pool%201.png)
 
 Hush is designed to incorporate core compliance features:
 

--- a/docs/docs/Hush/technical-architecture.md
+++ b/docs/docs/Hush/technical-architecture.md
@@ -5,6 +5,8 @@ title: Technical Architecture
 
 # Hush Protocol: Technical Architecture
 
+![Hush Technical Architecture](/img/litepaper/techinical%20architecture%20hush%201.png)
+
 ## Zero-Knowledge Foundation
 
 Hush uses **Miden zk-STARKs** as its proof system, chosen for two critical properties:
@@ -33,6 +35,8 @@ When a user shields tokens, they create a cryptographic commitment that is added
 5. **Voucher Creation**: A `ShieldedVoucher` is created with encrypted amount data
 
 ## Unshield Flow
+
+![Hush Unshield Flow](/img/litepaper/hush%20unshield%20flow%201.png)
 
 1. **Client**: User generates a zk-STARK proof demonstrating knowledge of a valid commitment in the tree and correct nullifier derivation
 2. **Proof Submission**: User submits the nullifier, Merkle root, zk-STARK proof, and recipient address

--- a/docs/docs/rock-token/allocation.md
+++ b/docs/docs/rock-token/allocation.md
@@ -5,6 +5,8 @@ title: Token Allocation
 
 # Token Allocation
 
+![Token Allocation Chart](/img/litepaper/token%20allocation%20chart%202%201.png)
+
 Fixed supply of 1 billion $ROCK:
 
 •        **Team:** 20.24%

--- a/docs/docs/rock-token/introduction.md
+++ b/docs/docs/rock-token/introduction.md
@@ -5,6 +5,8 @@ title: $ROCK
 
 # $ROCK
 
+![ROCK Token](/img/litepaper/rock%20token%20graphic%201.png)
+
 **Solana CA:** 5VsPJ2EG7jjo3k2LPzQVriENKKQkNUTzujEzuaj4Aisf
 
 zenBTC, Hush, and every future product built on zrChain share one thing: **$ROCK is the main value capture mechanism.** This is achieved via our Node Reward Pool architecture (detailed in the Staking $ROCK section).

--- a/docs/docs/rock-token/tokenomics.md
+++ b/docs/docs/rock-token/tokenomics.md
@@ -5,6 +5,8 @@ title: Tokenomic Design
 
 # Zenrock's Tokenomic Design
 
+![Zenrock Tokenomics Flow](/img/litepaper/zenrock%20tokenomics%20flow%20chart%201.png)
+
 **Every fee from every product built on Zenrock's infrastructure, whether developed by Zenrock Labs or any other team, is handled according to the same tokenomic framework.** Fees earned are distributed as follows:
 
 * **35% to Zenrock Labs:** operations, development, and $ROCK accumulation

--- a/docs/docs/zenBTC/introduction.md
+++ b/docs/docs/zenBTC/introduction.md
@@ -5,6 +5,8 @@ title: zenBTC
 
 # zenBTC
 
+![zenBTC](/img/litepaper/zenBTC.png)
+
 Mint: [https://zenbtc.app.zenrocklabs.io/](https://zenbtc.app.zenrocklabs.io/)
 
 CA: 9hX59xHHnaZXLU6quvm5uGY2iDiT3jczaReHy6A6TYKw

--- a/docs/docs/zenTP/introduction.md
+++ b/docs/docs/zenTP/introduction.md
@@ -5,6 +5,8 @@ title: zenTP
 
 # zenTP
 
+![zenTP](/img/litepaper/zenTP.png)
+
 Use zenTP: [https://app.zenrocklabs.io/zentp](https://app.zenrocklabs.io/zentp)
 
 Zenrock Transfer Protocol (zenTP) enables native $ROCK transfers between zrChain (Cosmos) and Solana. Unlike traditional bridges that wrap tokens, zenTP represents $ROCK as a native SPL token on Solana, providing the same user experience as any native Solana asset.

--- a/docs/docs/zenZEC/introduction.md
+++ b/docs/docs/zenZEC/introduction.md
@@ -5,6 +5,8 @@ title: zenZEC
 
 # zenZEC
 
+![zenZEC](/img/litepaper/zenZEC.png)
+
 Mint: [https://app.zenrocklabs.io/zenzec/crucible](https://app.zenrocklabs.io/zenzec/crucible)
 
 CA: JDt9rRGaieF6aN1cJkXFeUmsy7ZE4yY3CZb8tVMXVroS

--- a/docs/docs/zrChain/introduction.md
+++ b/docs/docs/zrChain/introduction.md
@@ -5,6 +5,8 @@ title: zrChain
 
 # zrChain
 
+![zrChain](/img/litepaper/zrChain.png)
+
 zrChain is a Delegated Proof-of-Stake chain built on the Cosmos SDK, purpose-built to run distributed multi-party computation with enshrined oracles that enable secure and complex cross-chain operations.
 
 At the core of Zenrock's dMPC is a threshold signature scheme (TSS). To produce a valid signature, multiple parties exchange key fragments, but the private key is never assembled. No participant, including Zenrock, ever has enough information to reconstruct it. **The key doesn't exist in any single location because it was never created in full. Only mathematical fragments exist.**
@@ -14,3 +16,5 @@ This allows zrChain to control wallets on any third-party blockchain without any
 **dMPC signature instructions can only originate from zrChain, making the entire signing process decentralized.** Through CometBFT Vote Extensions (a mechanism allowing validators to include additional data in their consensus votes), each validator runs an enshrined oracle sidecar as part of their node. This sidecar monitors events on external chains (for example, a deposit event on Bitcoin) and submits them directly into zrChain's core consensus process. Validators collectively observe the event, reach consensus, and only then does the chain instruct the dMPC to act. **By enshrining the oracle mechanism directly into core consensus, zrChain ensures that as long as the chain itself is secure, every instruction passed to the dMPC is legitimate.**
 
 zrChain launched with a genesis set of 8 dMPC operators and 60+ validators. These infrastructure providers possess significant cumulative stake across 50+ chains with geographic distribution across 22+ countries. Over time, the dMPC operator set will expand to 16, then 32, each time increasing the cryptographic threshold and security guarantees.
+
+![Zenrock Validators](/img/litepaper/Zenrock%20Validators.png)

--- a/docs/docs/zrChain/technical-architecture.md
+++ b/docs/docs/zrChain/technical-architecture.md
@@ -7,6 +7,8 @@ title: Technical Architecture
 
 ## Consensus & Validator Architecture
 
+![Consensus Architecture](/img/litepaper/consensus%20architecture%201.png)
+
 zrChain uses Delegated Proof-of-Stake with a hybrid validation model. The validator set includes both standard validators running consensus and a specialized subset of dMPC operators. This separation allows the network to scale the validator count for decentralization while maintaining a controlled set of cryptographic key holders for security-critical operations.
 
 ## dMPC Integration
@@ -34,6 +36,8 @@ This design ensures that external chain data is verified by the majority of vali
 
 ## Cross-Chain Observation
 
+![Cross-Chain Observation Security](/img/litepaper/cross%20chain%20observation%20security%20properties%201.png)
+
 The sidecar oracle monitors multiple blockchains simultaneously:
 
 - **Bitcoin & Zcash**: Block headers for SPV-style verification (Simplified Payment Verification, a lightweight method for confirming transactions via Merkle proofs)
@@ -51,6 +55,8 @@ zrChain inherits CometBFT's Byzantine fault tolerance (hence the BFT in the name
 - **Supply invariants**: Strict accounting ensures wrapped token supply equals custodied reserves
 
 ## Workspaces
+
+![Workspaces on zrChain](/img/litepaper/workspaces%20zrChain%201.png)
 
 Workspaces are the core organizational primitive on zrChain. Every dMPC key belongs to a workspace, not to an individual account. A workspace is a shared governance container, analogous to a team vault, where owners request keys, authorize signatures, and control access. This decouples key management from any single blockchain account, enabling teams, institutions, and individuals to manage cross-chain wallets under a shared governance structure.
 


### PR DESCRIPTION
## Summary

Integrates the litepaper assets into documentation pages for enhanced visual experience. This PR builds on #51 (add litepaper assets).

## Changes by Section

### zrChain
- **Introduction**: Added zrChain hero image and Zenrock Validators diagram
- **Technical Architecture**: Added consensus architecture, cross-chain observation security, and workspaces visualizations

### Hush Protocol
- **Introduction**: Added Hush protocol graphic and private economy pool visualization
- **Technical Architecture**: Added technical architecture diagram and unshield flow diagram

### DCT
- **Introduction**: Added Zenrock DCTs overview graphic

### Products
- **zenBTC**: Added product logo
- **zenTP**: Added product logo
- **zenZEC**: Added product logo

### ROCK Token
- **Introduction**: Added ROCK token graphic
- **Tokenomics**: Added tokenomics flow chart
- **Allocation**: Added token allocation chart

## Files Modified (11)

```
docs/docs/zrChain/introduction.md
docs/docs/zrChain/technical-architecture.md
docs/docs/Hush/introduction.md
docs/docs/Hush/technical-architecture.md
docs/docs/DCT/introduction.md
docs/docs/zenBTC/introduction.md
docs/docs/zenTP/introduction.md
docs/docs/zenZEC/introduction.md
docs/docs/rock-token/introduction.md
docs/docs/rock-token/tokenomics.md
docs/docs/rock-token/allocation.md
```

## PR Stack

- #51: Add litepaper assets to static/img/litepaper (base)
- **This PR**: Integrate assets into documentation pages

## Visual Impact

- Hero images on product pages (zenBTC, zenTP, zenZEC, Hush, DCT, ROCK)
- Technical diagrams in architecture sections
- Flow charts for tokenomics and processes
- Improved visual hierarchy and engagement

All images use URL-encoded paths for compatibility: `/img/litepaper/asset%20name.png`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)